### PR TITLE
fix build with non-Darwin Foundation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,8 +178,8 @@ jobs:
       run: xcodebuild test -workspace ".swiftpm/xcode/package.xcworkspace" -scheme "$SCHEME" -destination "platform=watchOS Simulator,name=$DESTNAME" | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
 
   linux:
-    name: linux
-    runs-on: ubuntu-latests
+    name: Linux
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,3 +176,13 @@ jobs:
     - name: Unit Tests
       if: steps.destnameprep.outcome != 'failure'
       run: xcodebuild test -workspace ".swiftpm/xcode/package.xcworkspace" -scheme "$SCHEME" -destination "platform=watchOS Simulator,name=$DESTNAME" | xcbeautify --renderer github-actions && exit ${PIPESTATUS[0]}
+
+  linux:
+    name: linux
+    runs-on: ubuntu-latests
+    steps:
+    - uses: actions/checkout@main
+    - name: Build
+      run: swift build
+    - name: Unit Tests
+      run: swift test

--- a/Sources/SwiftASCII/String.swift
+++ b/Sources/SwiftASCII/String.swift
@@ -46,7 +46,12 @@ extension StringProtocol {
     /// will be substituted.
     @available(OSX 10.11, iOS 9.0, *)
     public var asciiStringLossy: ASCIIString {
-        let transformed = applyingTransform(
+#if canImport(Darwin)
+        let this = self
+#else
+        let this = String(self) as NSString
+#endif
+        let transformed = this.applyingTransform(
             StringTransform("Latin-ASCII"),
             reverse: false
         )


### PR DESCRIPTION
non-Darwin platforms such as Linux require an explicit cast from String to NSString